### PR TITLE
Introduce async extensions for RouteFilters

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -44,9 +44,9 @@ jobs:
     - name: Build MTSC project
       run: dotnet build MTSC -c $env:Configuration
 
-    - name: Push nuget package
-      uses: brandedoutcast/publish-nuget@v2.5.5
-      with:
-         PROJECT_FILE_PATH: MTSC\MTSC.csproj
-         NUGET_KEY: ${{secrets.NUGET_API_KEY}}
+    - name: Package
+      run: dotnet pack -c Release -o . $env:Source_Project_Path
+
+    - name: Publish
+      run: dotnet nuget push *.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
     

--- a/MTSC.UnitTests/E2ETests.cs
+++ b/MTSC.UnitTests/E2ETests.cs
@@ -98,6 +98,8 @@ namespace MTSC.UnitTests
 
             Assert.IsTrue(NonActioningFilterAttribute.RequestCalled);
             Assert.IsTrue(NonActioningFilterAttribute.ResponseCalled);
+            Assert.IsTrue(NonActioningFilterAttribute.RequestAsyncCalled);
+            Assert.IsTrue(NonActioningFilterAttribute.ResponseAsyncCalled);
         }
 
         [TestMethod]

--- a/MTSC.UnitTests/RoutingModules/NonActioningFilterAttribute.cs
+++ b/MTSC.UnitTests/RoutingModules/NonActioningFilterAttribute.cs
@@ -1,5 +1,6 @@
 ﻿using MTSC.Common.Http;
 using MTSC.Common.Http.Attributes;
+using System.Threading.Tasks;
 
 namespace MTSC.UnitTests.RoutingModules
 {
@@ -7,6 +8,8 @@ namespace MTSC.UnitTests.RoutingModules
     {
         public static bool RequestCalled { get; private set; }
         public static bool ResponseCalled { get; private set; }
+        public static bool RequestAsyncCalled { get; private set; }
+        public static bool ResponseAsyncCalled { get; private set; }
 
         public override RouteEnablerResponse HandleRequest(RouteContext routeContext)
         {
@@ -18,6 +21,18 @@ namespace MTSC.UnitTests.RoutingModules
         {
             ResponseCalled = true;
             base.HandleResponse(routeContext);
+        }
+
+        public override Task<RouteEnablerAsyncResponse> HandleRequestAsync(RouteContext routeContext)
+        {
+            RequestAsyncCalled = true;
+            return base.HandleRequestAsync(routeContext);
+        }
+
+        public override Task HandleResponseAsync(RouteContext routeContext)
+        {
+            ResponseAsyncCalled = true;
+            return base.HandleResponseAsync(routeContext);
         }
     }
 }

--- a/MTSC/Common/Http/Attributes/RouteFilterAttribute.cs
+++ b/MTSC/Common/Http/Attributes/RouteFilterAttribute.cs
@@ -1,15 +1,20 @@
 ﻿using System;
+using System.Threading.Tasks;
 
 namespace MTSC.Common.Http.Attributes
 {
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
     public abstract class RouteFilterAttribute : Attribute
     {
-        public virtual RouteEnablerResponse HandleRequest(RouteContext routeFilterContext) => RouteEnablerResponse.Accept;
+        public virtual RouteEnablerResponse HandleRequest(RouteContext routeContext) => RouteEnablerResponse.Accept;
 
-        public virtual void HandleResponse(RouteContext routeFilterContext)
+        public virtual Task<RouteEnablerAsyncResponse> HandleRequestAsync(RouteContext routeContext) => Task.FromResult<RouteEnablerAsyncResponse>(RouteEnablerAsyncResponse.Accept);
+
+        public virtual void HandleResponse(RouteContext routeContext)
         {
         }
+
+        public virtual Task HandleResponseAsync(RouteContext routeContext) => Task.CompletedTask;
 
         public virtual RouteFilterExceptionHandlingResponse HandleException(RouteContext routeFilterContext, Exception exception)
         {

--- a/MTSC/Common/Http/RouteContext.cs
+++ b/MTSC/Common/Http/RouteContext.cs
@@ -1,4 +1,5 @@
-﻿using MTSC.ServerSide;
+﻿using MTSC.Common.Http.Attributes;
+using MTSC.ServerSide;
 using Slim;
 using System.Collections.Generic;
 using System.Threading;
@@ -12,6 +13,7 @@ namespace MTSC.Common.Http
         public ClientData Client { get; }
         public Dictionary<string, string> UrlValues { get; }
         public IServiceProvider ScopedServiceProvider { get; }
+        public List<RouteFilterAttribute> RouteFilters { get; } = new List<RouteFilterAttribute>();
         public HttpResponse HttpResponse { get; set; }
         public CancellationToken CancelRequest => this.Client.CancellationToken;
         public Dictionary<string, object> Resources { get; set; } = new();

--- a/MTSC/Common/Http/RouteEnablerAsyncResponse.cs
+++ b/MTSC/Common/Http/RouteEnablerAsyncResponse.cs
@@ -1,0 +1,27 @@
+﻿namespace MTSC.Common.Http
+{
+    public abstract class RouteEnablerAsyncResponse
+    {
+        public static RouteEnablerAsyncResponseAccept Accept { get; } = new RouteEnablerAsyncResponseAccept();
+        public static RouteEnablerAsyncResponseError Error(HttpResponse responseMessage)
+        {
+            return new RouteEnablerAsyncResponseError(responseMessage);
+        }
+
+        public sealed class RouteEnablerAsyncResponseAccept : RouteEnablerAsyncResponse
+        {
+            internal RouteEnablerAsyncResponseAccept()
+            {
+            }
+        }
+
+        public sealed class RouteEnablerAsyncResponseError : RouteEnablerAsyncResponse
+        {
+            public HttpResponse Response { get; }
+            internal RouteEnablerAsyncResponseError(HttpResponse responseMessage)
+            {
+                this.Response = responseMessage;
+            }
+        }
+    }
+}

--- a/MTSC/MTSC.csproj
+++ b/MTSC/MTSC.csproj
@@ -5,13 +5,13 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <ApplicationIcon />
     <StartupObject />
-    <Version>5.3.0</Version>
+    <Version>5.4.0</Version>
     <LangVersion>latest</LangVersion>
     <Authors>Alexandru-Victor Macocian</Authors>
     <Product>MTSC</Product>
     <Description>Modular TCP Server and Client</Description>
-    <AssemblyVersion>5.3.0.0</AssemblyVersion>
-    <FileVersion>5.3.0.0</FileVersion>
+    <AssemblyVersion>5.4.0.0</AssemblyVersion>
+    <FileVersion>5.4.0.0</FileVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Platforms>AnyCPU;x64</Platforms>
     <PackageProjectUrl>https://github.com/AlexMacocian/MTSC</PackageProjectUrl>


### PR DESCRIPTION
Rework filter logic to reuse filter objects on the scope of a request